### PR TITLE
Change mechanism to retrieve number of CPUs

### DIFF
--- a/scripts/build-openfhe-development.sh
+++ b/scripts/build-openfhe-development.sh
@@ -29,7 +29,7 @@ fi
 echo "OPENFHE_INSTALL_DIR set to $OPENFHE_INSTALL_DIR"
 cmake $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX=$OPENFHE_INSTALL_DIR .. || abort "Failure of cmake in openfhe-development."
 
-CPUS=`lscpu | egrep "^CPU\(s\)" | awk '{print $2}'`
+CPUS=`nproc`
 if [ $CPUS -lt 1 ]; then
   CPUS=1
 fi


### PR DESCRIPTION
Fixes build fail when using newer version of util-linux, fixing #7 and removing a deprecated warning for egrep at the same time